### PR TITLE
Tokenless files access

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ heroku config:add EXTRA_ARGS="--proxy=<proxy> --local" -a <heroku-app-name>
 ```
 > Additionally, you can add bot-tokens too _(along with bot-id)_ for any bot, in ALLOWED_BOT_IDS.
 > This way, you can get the files from server, without the need of bot token _(for that bot)_. _(Token won't be exposed)_
-> Example: ALLOWED_BOT_IDS=<bot-id>,<bot-id>:<bot-token>,<bot-id>
+> Example: `ALLOWED_BOT_IDS=<bot-id>,<bot-id>:<bot-token>,<bot-id>`
 
 ### Push container to heroku
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ heroku config:add TELEGRAM_API_ID=<api-id> TELEGRAM_API_HASH=<api-hash> -a <hero
 # NOTE: To pass extra arguments to telegram-bot-api, you can add the environment var EXTRA_ARGS
 heroku config:add EXTRA_ARGS="--proxy=<proxy> --local" -a <heroku-app-name>
 ```
-
+> Additionally, you can add bot-tokens too _(along with bot-id)_ for any bot, in ALLOWED_BOT_IDS.
+> This way, you can get the files from server, without the need of bot token _(for that bot)_. _(Token won't be exposed)_
+> Example: ALLOWED_BOT_IDS=<bot-id>,<bot-id>:<bot-token>,<bot-id>
 
 ### Push container to heroku
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ heroku config:add TELEGRAM_API_ID=<api-id> TELEGRAM_API_HASH=<api-hash> -a <hero
 # NOTE: To pass extra arguments to telegram-bot-api, you can add the environment var EXTRA_ARGS
 heroku config:add EXTRA_ARGS="--proxy=<proxy> --local" -a <heroku-app-name>
 ```
-> Additionally, you can add bot-tokens too _(along with bot-id)_ for any bot, in ALLOWED_BOT_IDS.
-> This way, you can get the files from server, without the need of bot token _(for that bot)_. _(Token won't be exposed)_
+> **Optionally,** you can add full-tokens to ALLOWED_BOT_IDS, if you want to avoid exposing your token when sharing links to your bot files.
 > Example: `ALLOWED_BOT_IDS=<bot-id>,<bot-id>:<bot-token>,<bot-id>`
 
 ### Push container to heroku

--- a/proxy.py
+++ b/proxy.py
@@ -35,7 +35,7 @@ def sanitize(token: str) -> str:
 def is_unauthorized(token: Union[str,None]):
   """ Returns True, if bot is unauthorized """
   bot_id = token.split(':')[0] if token else None
-  return bot_id not in allowedBotIds or token is None
+  return bot_id not in allowedBotIds
 
 
 def make_error(code: int):

--- a/proxy.py
+++ b/proxy.py
@@ -28,8 +28,8 @@ for i in allowedBots:
 
 
 
-def sanitize(token: str) -> str:
-  return token.replace('bot', '', 1)
+def sanitize(token: Union[str, None]) -> str:
+  return token if token is None else token.replace('bot', '', 1)
 
 
 def is_unauthorized(token: Union[str,None]):
@@ -44,9 +44,9 @@ def make_error(code: int):
 
 def get_path_data(path: str):
   """ Returns the filename and token from the path """
-  pathParts = sanitize(path).split('/') if path else [None]
+  pathParts = path.split('/') if path else [None]
   filename, token = pathParts[-1], pathParts[0]
-  return filename, token
+  return filename, sanitize(token)
 
 
 def unpack(source: List[str], target: int, default_value=None):
@@ -89,13 +89,13 @@ def file(u_path: str):
     botToken = allowedBotIds.get(bot_id)
     if botToken:
       u_path = u_path.replace(bot_id, f'{bot_id}:{botToken}', 1)
-  u_path = f'/file/{sanitize(u_path)}'
+  filePath = f'/file/{sanitize(u_path)}'
 
   if not os.path.exists(u_path):
     return make_error(404)
 
   return send_file(
-    path_or_file=u_path,
+    path_or_file=filePath,
     mimetype='application/octet-stream',
     download_name=filename,
     as_attachment=True

--- a/proxy.py
+++ b/proxy.py
@@ -57,19 +57,17 @@ def unpack(source: List[str], target: int, default_value=None):
   return source
 
 
-def request(reqUrl:Union[str,None]=None):
-  """ Send all HTTP request to telegram-bot-api local server 
-  - If `reqUrl` is passed, it would be used instead of `req.url` for the url argument
-  """
-  rdata = req.get_data() # Capture data before cleaning
-  content_type = 'application/json' # Fix Content-Type header when opening URL in browser
+def request():
+  """ Send all HTTP request to telegram-bot-api local server """
+  rdata = req.get_data()                                        # Capture data before cleaning
+  content_type = 'application/json'                             # Fix Content-Type header when opening URL in browser
 
-  if 'Content-Type' in req.headers:   content_type = req.headers['Content-Type']
-  if reqUrl is None:                  reqUrl = req.url
+  if 'Content-Type' in req.headers:
+    content_type = req.headers['Content-Type']
 
   return got(
     method=req.method,
-    url=reqUrl.replace(req.host_url, 'http://127.0.0.1:8081/'),
+    url=req.url.replace(req.host_url, 'http://127.0.0.1:8081/'),
     headers={'Content-Type': content_type, 'Connection': 'keep-alive'},
     params=req.args,
     data=rdata

--- a/proxy.py
+++ b/proxy.py
@@ -74,6 +74,19 @@ def request(reqUrl:str|None=None):
   )
 
 
+def tokenized_url(bot_id:str):
+  """ Returns: `Request.request.url` after appending bot-token to it (if not present) """
+  # Original url
+  reqUrl = req.url
+  
+  # If bot-token absent in URL but present in ALLOWED_BOT_IDS -> append bot-token to url
+  botToken = allowedBotIds.get(bot_id)
+  if botToken and f'{bot_id}:' not in reqUrl:                           # ':' defines if a token is present or not
+    reqUrl = reqUrl.replace(bot_id, f'{bot_id}:{botToken}')
+    
+  return reqUrl
+
+
 @app.route('/file/<path:u_path>', methods=['GET'])
 def file(u_path: str):
   """ Handle local files """

--- a/proxy.py
+++ b/proxy.py
@@ -91,7 +91,7 @@ def file(u_path: str):
   filePath = f'/file/{sanitize(u_path)}'
 
   # Check if file exists
-  if not os.path.exists(u_path):
+  if not os.path.exists(filePath):
     return make_error(404)
 
   return send_file(

--- a/proxy.py
+++ b/proxy.py
@@ -42,8 +42,8 @@ def make_error(code: int):
 
 
 def get_path_data(path: str):
-  path = sanitize(path)
-  token, *__, filename = unpack(path.split('/'), 5)
+  pathParts = sanitize(path).split('/')
+  filename, token = pathParts[-1], pathParts[0]
   return filename, token
 
 

--- a/proxy.py
+++ b/proxy.py
@@ -42,7 +42,7 @@ def make_error(code: int):
   return jsonify(errors[str(code)]), code
 
 
-def get_path_data(path: str):
+def get_path_data(path: Union[str,None]):
   """ Returns the filename and token from the path """
   pathParts = path.split('/') if path else [None]
   filename, token = pathParts[-1], pathParts[0]

--- a/proxy.py
+++ b/proxy.py
@@ -18,9 +18,9 @@ errors = {
   '404': {'ok': False, 'error_code': 404, 'description': 'Not found'}
 }
 
-# Allowed bots data from env
-allowedBots = os.environ.get('ALLOWED_BOT_IDS', '').split(',')
-allowedBotIds :dict[str, Union[str,None]] = {}                         # {botid: bot-token}
+# [Parsing] Allowed bots data from env
+allowedBots = os.environ.get('ALLOWED_BOT_IDS', '').split(',')                    # botid,botid:bottoken,botid,....
+allowedBotIds :dict[str, Union[str,None]] = {}                                    # {botid: bot-token}
 for i in allowedBots:
   if ':' in i:    botID, botToken = i.split(':', 1)
   else:           botID, botToken = i, None
@@ -33,6 +33,7 @@ def sanitize(token: str) -> str:
 
 
 def is_unauthorized(token: Union[str,None]):
+  """ Returns True, if bot is unauthorized """
   bot_id = token.split(':')[0] if token else None
   return bot_id not in allowedBotIds or token is None
 
@@ -42,6 +43,7 @@ def make_error(code: int):
 
 
 def get_path_data(path: str):
+  """ Returns the filename and token from the path """
   pathParts = sanitize(path).split('/')
   filename, token = pathParts[-1], pathParts[0]
   return filename, token

--- a/proxy.py
+++ b/proxy.py
@@ -44,7 +44,7 @@ def make_error(code: int):
 
 def get_path_data(path: str):
   """ Returns the filename and token from the path """
-  pathParts = sanitize(path).split('/')
+  pathParts = sanitize(path).split('/') if path else [None]
   filename, token = pathParts[-1], pathParts[0]
   return filename, token
 

--- a/proxy.py
+++ b/proxy.py
@@ -28,7 +28,7 @@ for i in allowedBots:
 
 
 
-def sanitize(token: Union[str, None]) -> str:
+def sanitize(token: Union[str, None]):
   return token if token is None else token.replace('bot', '', 1)
 
 
@@ -80,7 +80,7 @@ def file(u_path: str):
   """ Handle local files """
   filename, token = get_path_data(u_path)
 
-  if is_unauthorized(token):
+  if token is None or is_unauthorized(token):
     return make_error(401)
 
   # Getting correct filepath for the file
@@ -108,7 +108,7 @@ def api(u_path: str):
   """ Handle all API request """
   __, token = get_path_data(u_path)
 
-  if is_unauthorized(token):
+  if token is None or is_unauthorized(token):
     return make_error(401)
 
   res = request()

--- a/proxy.py
+++ b/proxy.py
@@ -2,7 +2,7 @@
   Credits to https://github.com/sayyid5416
   Proxy to restrict bots that are not owned by you
 """
-from typing import List
+from typing import List, Union
 from os import environ as env
 from requests import request as got
 from flask import Flask, request as req, send_file
@@ -20,7 +20,7 @@ errors = {
 
 # Allowed bots data from env
 allowedBots = env.get('ALLOWED_BOT_IDS', '').split(',')
-allowedBotIds :dict[str, str|None] = {}                         # {botid: bot-token}
+allowedBotIds :dict[str, Union[str,None]] = {}                         # {botid: bot-token}
 for i in allowedBots:
   if ':' in i:    botID, botToken = i.split(':', 1)
   else:           botID, botToken = i, None
@@ -32,7 +32,7 @@ def sanitize(token: str) -> str:
   return token.replace('bot', '', 1)
 
 
-def is_unauthorized(token: str|None):
+def is_unauthorized(token: Union[str,None]):
   bot_id = token.split(':')[0] if token else None
   return bot_id not in allowedBotIds or token is None
 
@@ -55,7 +55,7 @@ def unpack(source: List[str], target: int, default_value=None):
   return source
 
 
-def request(reqUrl:str|None=None):
+def request(reqUrl:Union[str,None]=None):
   """ Send all HTTP request to telegram-bot-api local server 
   - If `reqUrl` is passed, it would be used instead of `req.url` for the url argument
   """

--- a/proxy.py
+++ b/proxy.py
@@ -9,13 +9,24 @@ from flask import Flask, request as req, send_file
 from flask.json import jsonify
 from flask_cors import CORS
 
+
+# Init
 app: Flask = Flask(__name__)
 CORS(app)
-allowedBotIds = env.get('ALLOWED_BOT_IDS', '').split(',')
 errors = {
   '401': {'ok': False, 'error_code': 401, 'description': 'Unauthorized'},
   '404': {'ok': False, 'error_code': 404, 'description': 'Not found'}
 }
+
+# Allowed bots data from env
+allowedBots = env.get('ALLOWED_BOT_IDS', '').split(',')
+allowedBotIds :dict[str, str|None] = {}                         # {botid: bot-token}
+for i in allowedBots:
+  if ':' in i:    botID, botToken = i.split(':', 1)
+  else:           botID, botToken = i, None
+  allowedBotIds.update({botID: botToken})
+
+
 
 def sanitize(token: str) -> str:
   return token.replace('bot', '', 1)

--- a/proxy.py
+++ b/proxy.py
@@ -55,16 +55,19 @@ def unpack(source: List[str], target: int, default_value=None):
   return source
 
 
-def request():
-  """ Send all HTTP request to telegram-bot-api local server """
+def request(reqUrl:str|None=None):
+  """ Send all HTTP request to telegram-bot-api local server 
+  - If `reqUrl` is passed, it would be used instead of `req.url` for the url argument
+  """
   rdata = req.get_data() # Capture data before cleaning
   content_type = 'application/json' # Fix Content-Type header when opening URL in browser
 
   if 'Content-Type' in req.headers:   content_type = req.headers['Content-Type']
+  if reqUrl is None:                  reqUrl = req.url
 
   return got(
     method=req.method,
-    url=req.url.replace(req.host_url, 'http://127.0.0.1:8081/'),
+    url=reqUrl.replace(req.host_url, 'http://127.0.0.1:8081/'),
     headers={'Content-Type': content_type, 'Connection': 'keep-alive'},
     params=req.args,
     data=rdata

--- a/proxy.py
+++ b/proxy.py
@@ -4,7 +4,6 @@
 """
 import os
 from typing import List, Union
-from os import environ as env
 from requests import request as got
 from flask import Flask, request as req, send_file
 from flask.json import jsonify
@@ -20,7 +19,7 @@ errors = {
 }
 
 # Allowed bots data from env
-allowedBots = env.get('ALLOWED_BOT_IDS', '').split(',')
+allowedBots = os.environ.get('ALLOWED_BOT_IDS', '').split(',')
 allowedBotIds :dict[str, Union[str,None]] = {}                         # {botid: bot-token}
 for i in allowedBots:
   if ':' in i:    botID, botToken = i.split(':', 1)

--- a/proxy.py
+++ b/proxy.py
@@ -21,8 +21,8 @@ def sanitize(token: str) -> str:
   return token.replace('bot', '', 1)
 
 
-def is_unauthorized(token: str):
-  bot_id, token = unpack(sanitize(token).split(':'), 2)
+def is_unauthorized(token: str|None):
+  bot_id = token.split(':')[0] if token else None
   return bot_id not in allowedBotIds or token is None
 
 
@@ -49,8 +49,7 @@ def request():
   rdata = req.get_data() # Capture data before cleaning
   content_type = 'application/json' # Fix Content-Type header when opening URL in browser
 
-  if 'Content-Type' in req.headers:
-    content_type = req.headers['Content-Type']
+  if 'Content-Type' in req.headers:   content_type = req.headers['Content-Type']
 
   return got(
     method=req.method,

--- a/proxy.py
+++ b/proxy.py
@@ -83,14 +83,14 @@ def file(u_path: str):
   if is_unauthorized(token):
     return make_error(401)
 
-  # Check if file exists via HTTP request for more faster
+  # Getting correct filepath for the file
   bot_id = token.split(':', 1)[0]
-  if f'{bot_id}:' not in u_path:                           # ':' defines if a token is present or not
+  if f'{bot_id}:' not in u_path:                           # ':' signifies if a token is present or not
     botToken = allowedBotIds.get(bot_id)
-    if botToken:
-      u_path = u_path.replace(bot_id, f'{bot_id}:{botToken}', 1)
+    if botToken: u_path = u_path.replace(bot_id, f'{bot_id}:{botToken}', 1)
   filePath = f'/file/{sanitize(u_path)}'
 
+  # Check if file exists
   if not os.path.exists(u_path):
     return make_error(404)
 

--- a/proxy.py
+++ b/proxy.py
@@ -96,7 +96,8 @@ def file(u_path: str):
     return make_error(401)
 
   # Check if file exists via HTTP request for more faster
-  res = request()
+  bot_id = token.split(':', 1)[0]
+  res = request(reqUrl=tokenized_url(bot_id))
 
   if res.status_code != 200:
     return make_error(404)

--- a/proxy.py
+++ b/proxy.py
@@ -42,6 +42,7 @@ def make_error(code: int):
 
 
 def get_path_data(path: str):
+  path = sanitize(path)
   token, *__, filename = unpack(path.split('/'), 5)
   return filename, token
 


### PR DESCRIPTION
# User A: 
ALLOWED_BOT_IDS = 'botid1,botid2,botid3'
- Can access files like `hostUrl/files/botid:token/documents/file_0.txt`

# User B:
ALLOWED_BOT_IDS = 'botid1:bottoken1,botid2:bottoken2,botid3:bottoken3'
- Can access files like `hostUrl/files/botid/documents/file_0.txt`, or
- Can access files like `hostUrl/files/botid:token/documents/file_0.txt` _(priority would be given to this token instead of in config vars)_
- Token part can be fetched from ALLOWED_BOT_IDS

# Other info
- **API** would still require **id and token both** for all the users _(no matter what's in the ALLOWED_BOT_IDS)_
- Restrictions for public bots is still based on the bot-ids.